### PR TITLE
Dockerfile for assetMantle with supporting Make commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,22 @@
-FROM golang:1.14-alpine AS build-env
+FROM golang:1.14-buster
 
 # Set up dependencies
-ENV PACKAGES curl make git libc-dev bash gcc linux-headers eudev-dev python3
+ENV PACKAGES curl make git
+ENV PATH=/root/.cargo/bin:$PATH
 
 # Set working directory for the build
-WORKDIR /go/src/app
+WORKDIR /usr/local/app
 
-# Add source files
-COPY . .
+# Install minimum necessary dependencies
+RUN apt update && apt install -y $PACKAGES
 
-RUN go version
-
-# Install minimum necessary dependencies, build persistenceCore, remove packages
-RUN apk add --no-cache $PACKAGES \
-    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -y | sh
-
-# Install wasmd
-RUN git clone https://github.com/CosmWasm/wasmd.git \
-    && cd wasmd \
-    && git checkout v0.10.0 \
-    && make install
-
-RUN make build
-
-# Final image
-FROM alpine:edge
-
-# Install ca-certificates
-RUN apk add --update ca-certificates
+# Install Rust and wasm32 dependencies
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN rustup default stable \
+    && rustup default stable \
+    && rustup update stable \
+    && rustup target list --installed \
+    && rustup target add wasm32-unknown-unknown
 
 # Create appuser
 ENV USER=appuser
@@ -41,11 +30,11 @@ RUN adduser \
     "${USER}"
 USER 10001
 
-WORKDIR /app
+# Add source files
+COPY . .
 
-# Copy over binaries from the build-env
-COPY --from=build-env /go/bin/assetClient /usr/bin/assetClient
-COPY --from=build-env /go/bin/assetNode /usr/bin/assetNode
+# Build client
+RUN make install
 
 # Run persistenceCore by default, omit entrypoint to ease using container with cli
 CMD ["assetClient"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+FROM golang:1.14-alpine AS build-env
+
+# Set up dependencies
+ENV PACKAGES curl make git libc-dev bash gcc linux-headers eudev-dev python3
+
+# Set working directory for the build
+WORKDIR /go/src/app
+
+# Add source files
+COPY . .
+
+RUN go version
+
+# Install minimum necessary dependencies, build persistenceCore, remove packages
+RUN apk add --no-cache $PACKAGES \
+    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -y | sh
+
+# Install wasmd
+RUN git clone https://github.com/CosmWasm/wasmd.git \
+    && cd wasmd \
+    && git checkout v0.10.0 \
+    && make install
+
+RUN make build
+
+# Final image
+FROM alpine:edge
+
+# Install ca-certificates
+RUN apk add --update ca-certificates
+
+# Create appuser
+ENV USER=appuser
+ENV UID=10001
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/app" \
+    --shell "/sbin/nologin" \
+    --uid "${UID}" \
+    "${USER}"
+USER 10001
+
+WORKDIR /app
+
+# Copy over binaries from the build-env
+COPY --from=build-env /go/bin/assetClient /usr/bin/assetClient
+COPY --from=build-env /go/bin/assetNode /usr/bin/assetNode
+
+# Run persistenceCore by default, omit entrypoint to ease using container with cli
+CMD ["assetClient"]

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=assetMantle \
 		  -X github.com/cosmos/cosmos-sdk/version.ClientName=assetClient \
 		  -X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) \
 		  -X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) \
-		  -X github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags_comma_sep)
+		  -X github.com/cosmos/cosmos-sdk/version.BuildTags=$(build_tags_comma_sep) \
 
 BUILD_FLAGS += -ldflags "${ldflags}"
 
@@ -19,12 +19,12 @@ GOBIN = $(shell go env GOPATH)/bin
 # Docker variables
 DOCKER := $(shell which docker)
 
-DOCKER_IMAGE_NAME = persistenceone/persistencecore
+DOCKER_IMAGE_NAME = persistenceone/assetmantle
 DOCKER_TAG_NAME = latest
-DOCKER_CONTAINER_NAME = persistence-core-container
+DOCKER_CONTAINER_NAME = assetmantle-container
 DOCKER_CMD ?= "/bin/sh"
 
-.PHONY: all install build verify
+.PHONY: all install build verify docker-run docker-interactive
 
 all: verify build
 
@@ -74,7 +74,7 @@ docker-run:
 	${DOCKER} run ${DOCKER_OPTS} --name=${DOCKER_CONTAINER_NAME} ${DOCKER_IMAGE_NAME}:${DOCKER_TAG_NAME} ${DOCKER_CMD}
 
 docker-interactive:
-	${MAKE} docker-run DOCKER_CMD=/bin/sh DOCKER_OPTS=--rm --it
+	${MAKE} docker-run DOCKER_CMD=/bin/sh DOCKER_OPTS="--rm -it"
 
 docker-clean-container:
 	-${DOCKER} stop ${DOCKER_CONTAINER_NAME}

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ COMMIT := $(shell git rev-parse --short HEAD)
 
 build_tags = netgo
 build_tags_comma_sep := $(subst $(whitespace),$(comma),$(build_tags))
-
 ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=assetMantle \
 		  -X github.com/cosmos/cosmos-sdk/version.ServerName=assetNode \
 		  -X github.com/cosmos/cosmos-sdk/version.ClientName=assetClient \
@@ -17,36 +16,71 @@ BUILD_FLAGS += -ldflags "${ldflags}"
 
 GOBIN = $(shell go env GOPATH)/bin
 
+# Docker variables
+DOCKER := $(shell which docker)
+
+DOCKER_IMAGE_NAME = persistenceone/persistencecore
+DOCKER_TAG_NAME = latest
+DOCKER_CONTAINER_NAME = persistence-core-container
+DOCKER_CMD ?= "/bin/sh"
+
+.PHONY: all install build verify
+
 all: verify build
 
 install:
 ifeq (${OS},Windows_NT)
-	
-	go build -mod=readonly ${BUILD_FLAGS} -o ${GOBIN}/assetClient.exe ./client
-	go build -mod=readonly ${BUILD_FLAGS} -o ${GOBIN}/assetNode.exe ./node
-
+	go install -mod=readonly ${BUILD_FLAGS} -o ${GOBIN}/assetClient.exe ./client
+	go install -mod=readonly ${BUILD_FLAGS} -o ${GOBIN}/assetNode.exe ./node
 else
-	
 	go build -mod=readonly ${BUILD_FLAGS} -o ${GOBIN}/assetClient ./client
 	go build -mod=readonly ${BUILD_FLAGS} -o ${GOBIN}/assetNode ./node
-
 endif
 
 build:
 ifeq (${OS},Windows_NT)
-
 	go build  ${BUILD_FLAGS} -o ${GOBIN}/assetClient.exe ./client
 	go build  ${BUILD_FLAGS} -o ${GOBIN}/assetNode.exe ./node
-
 else
-
 	go build  ${BUILD_FLAGS} -o ${GOBIN}/assetClient ./client
 	go build  ${BUILD_FLAGS} -o ${GOBIN}/assetNode ./node
-
 endif
 
 verify:
 	@echo "verifying modules"
 	@go mod verify
 
-.PHONY: all install build verify
+
+# Commands for running docker
+#
+# Run persistenceCore on docker
+# Example Usage:
+# 	make docker-build   ## Builds persistenceCore binary in 2 stages, 1st builder 2nd Runner
+# 						   Final image only has the compiled persistenceCore binary
+# 	make docker-interactive   ## Will start an shell session into the docker container
+# 								 Access to persistenceCore binary here
+# 		NOTE: To be used for testing only, since the container will be removed after stopping
+# 	make docker-run DOCKER_CMD=sleep 10000000 DOCKER_OPTS=-d   ## Will run the container in the background
+# 		NOTE: Recommeded to use docker commands directly for long running processes
+# 	make docker-clean  # Will clean up the running container, as well as delete the image
+# 						 after one is done testing
+docker-build:
+	${DOCKER} build -t ${DOCKER_IMAGE_NAME}:${DOCKER_TAG_NAME} .
+
+docker-build-push: docker-build
+	${DOCKER} push ${DOCKER_IMAGE_NAME}:${DOCKER_TAG_NAME}
+
+docker-run:
+	${DOCKER} run ${DOCKER_OPTS} --name=${DOCKER_CONTAINER_NAME} ${DOCKER_IMAGE_NAME}:${DOCKER_TAG_NAME} ${DOCKER_CMD}
+
+docker-interactive:
+	${MAKE} docker-run DOCKER_CMD=/bin/sh DOCKER_OPTS=--rm --it
+
+docker-clean-container:
+	-${DOCKER} stop ${DOCKER_CONTAINER_NAME}
+	-${DOCKER} rm ${DOCKER_CONTAINER_NAME}
+
+docker-clean-image:
+	-${DOCKER} rmi ${DOCKER_IMAGE_NAME}:${DOCKER_TAG_NAME}
+
+docker-clean: docker-clean-container docker-clean-image


### PR DESCRIPTION
## 1. Overview
This PR creates dockerfile and make commands for running for docker container for building the assetMantle binaries for client and node.
Current solution is based on `buster` Debian image, since alpine has `muslc` dependency which is not fully supported by `wasmd`. https://github.com/CosmWasm/wasmd/issues/105
Due to assetMantle dependencies on `rust` and `wasmd` we can not build a bare bone image with only the final binaries

## 2. Implementation details
 - Built on top of `buster` docker image for golang
 - Docker image installs `rustup` and its dependencies 
 - Add docker build and run commands for running containers locally

## 3. How to test/use
Run `make docker-build docker-interactive` to build the docker image locally and run the bash into the container. Run `assetClient` and `assetNode` commands to verify working

## 4. Future Work (optional)
- Build alpine based image with all dependencies for lighter image. 
- Build supporting docker image and container to test assetMantle with full suite.